### PR TITLE
[VSSL-3592] update on cluster bootstrapper

### DIFF
--- a/tools/bootstrap-cluster/bootstrap-cluster.sh
+++ b/tools/bootstrap-cluster/bootstrap-cluster.sh
@@ -369,12 +369,14 @@ if [ "$K0S_ROLE" == "controller" ]; then
     bold "If the problem persists after retry, please reach out support@vessl.ai for technical support."
     abort ""
   fi
-  unset jsonpath
 
   if [ "$K0S_TAINT_CONTROLLER" == "false" ]; then
     bold "Untainting control plane node (workloads can be scheduled to control plane node)"
-    sudo $k0s_executable kubectl taint nodes --selector=$control_plane_label node-role.kubernetes.io/control-plane:NoSchedule || true
+    sudo $k0s_executable kubectl taint nodes --selector=$control_plane_label node-role.kubernetes.io/control-plane:NoSchedule- || true
   fi
+
+  unset jsonpath
+  unset control_plane_label
 fi
 
 bold "-------------------\nBootstrap complete!\n-------------------\n"


### PR DESCRIPTION
* flag를 받는 방식을 `--flag={value}` 하는 식으로 한 덩어리에서 `=` 기호로 분리하게 수정하였습니다.
* control plane의 경우 처음으로 클러스터를 생성하는 경우이므로 node가 ready 상태인지 친절하게 확인해줍니다.
* K0S_TAINT_CONTROLLER 옵션을 추가합니다. true일때만 master에 taint를 발라서 워크로드가 스케줄 안되게 해줍니다.
  * default false인 이유는 보통 dedicated master node를 운영하는 경우는 큰 엔터프라이즈가 아닌 이상 잘 없기 때문입니다. (싱글 노드를 바로 엮으려는 smb/startup 유저 혹은 학교/랩 레벨)